### PR TITLE
Setup Conda based CI  MacOS workflow

### DIFF
--- a/.github/workflows/conda-ci.yml
+++ b/.github/workflows/conda-ci.yml
@@ -10,8 +10,7 @@ on:
 
 env:
   manif_TAG: 0.0.4
-  blf_TAG: 0.2.0
-  GTSAM_TAG: 4.0.3
+  blf_TAG: v0.2.0
 
 jobs:
   build:
@@ -38,21 +37,63 @@ jobs:
         # Compilation related dependencies
         mamba install cmake compilers make ninja pkg-config
         # Actual dependencies
-        mamba install -c robotology idyntree eigen manif spdlog libmatio matio-cpp opencv pcl catch2 yarp
+        mamba install -c robotology idyntree eigen manif spdlog libmatio matio-cpp opencv pcl catch2 yarp nlohmann_json
 
-    - name: Dependencies [Source Based - Linux&macOS]
-      if: contains(matrix.os, 'macos') || contains(matrix.os, 'ubuntu')
+    - name: Boost Dependency [Ubuntu]
+      if: contains(matrix.os, 'ubuntu')
+      shell: bash -l {0}
+      run: |
+        mamba install boost=1.58.0
+
+    - name: Boost Dependency [Windows]
+      if: contains(matrix.os, 'windows')
+      shell: bash -l {0}
+      run: |
+        mamba install boost=1.67.0
+
+    - name: Boost Dependency [MacOS]
+      if: contains(matrix.os, 'macos')
+      shell: bash -l {0}
+      run: |
+        mamba install -c robotology boost
+
+    - name: GTSAM Dependency [Source Based - Linux]
+      if: contains(matrix.os, 'ubuntu')
+      env:
+          BOOST_ROOT: ${{ steps.install-boost-windows.outputs.BOOST_ROOT }}
       shell: bash -l {0}
       run: |
         # GTSAM
         cd ${GITHUB_WORKSPACE}
-        git clone -b ${GTSAM_TAG} https://github.com/borglab/gtsam
+        git clone https://github.com/borglab/gtsam
         cd gtsam
         mkdir -p build
         cd build
-        cmake -GNinja -DCMAKE_INSTALL_PREFIX=${CONDA_PREFIX} ..
+        cmake -GNinja \
+              -DBOOST_ROOT="${env:BOOST_ROOT}" \
+              -DBOOST_INCLUDEDIR="${env:BOOST_ROOT}\boost\include" \
+              -DBOOST_LIBRARYDIR="${env:BOOST_ROOT}\lib" \
+              -DCMAKE_INSTALL_PREFIX=${CONDA_PREFIX} ..
         cmake --build . --config ${{ matrix.build_type }} --target install
 
+    - name: GTSAM Dependency [Source Based - MacOS]
+      if: contains(matrix.os, 'macos')
+      shell: bash -l {0}
+      run: |
+        # GTSAM
+        cd ${GITHUB_WORKSPACE}
+        git clone https://github.com/borglab/gtsam
+        cd gtsam
+        mkdir -p build
+        cd build
+        cmake -GNinja \
+              -DCMAKE_INSTALL_PREFIX=${CONDA_PREFIX} ..
+        cmake --build . --config ${{ matrix.build_type }} --target install
+
+    - name: Dependencies [Source Based - Linux&MacOS]
+      if: contains(matrix.os, 'macos') || contains(matrix.os, 'ubuntu')
+      shell: bash -l {0}
+      run: |
         # bipedal-locomotion-framework
         cd ${GITHUB_WORKSPACE}
         git clone -b ${blf_TAG} https://github.com/dic-iit/bipedal-locomotion-framework
@@ -64,17 +105,19 @@ jobs:
 
     - name: Dependencies [Source Based - windows]
       if: contains(matrix.os, 'windows')
+      env:
+          BOOST_ROOT: ${{ steps.install-boost-windows.outputs.BOOST_ROOT }}
       shell: bash -l {0}
       run: |
         # GTSAM
         cd ${GITHUB_WORKSPACE}
-        git clone -b ${GTSAM_TAG} https://github.com/borglab/gtsam
+        git clone https://github.com/borglab/gtsam
         cd gtsam
         mkdir -p build
         cd build
         cmake -G"Visual Studio 16 2019" \
               -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
-              -DCMAKE_INSTALL_PREFIX=${CONDA_PREFIX}/Library ..
+              -DCMAKE_INSTALL_PREFIX=${CONDA_PREFIX}/Library  ..
         cmake --build . --config ${{ matrix.build_type }} --target install
 
         # bipedal-locomotion-framework
@@ -88,7 +131,7 @@ jobs:
               -DCMAKE_INSTALL_PREFIX=${CONDA_PREFIX}/Library ..
         cmake --build . --config ${{ matrix.build_type }} --target install
 
-    - name: Configure [Linux&macOS]
+    - name: Configure [Linux&MacOS]
       if: contains(matrix.os, 'macos') || contains(matrix.os, 'ubuntu')
       shell: bash -l {0}
       run: |

--- a/.github/workflows/conda-ci.yml
+++ b/.github/workflows/conda-ci.yml
@@ -1,0 +1,120 @@
+name: C++ CI Workflow with conda-forge dependencies
+
+on:
+  push:
+  pull_request:
+  schedule:
+  # * is a special character in YAML so you have to quote this string
+  # Execute a "nightly" build at 2 AM UTC
+  - cron:  '0 2 * * *'
+
+env:
+  manif_TAG: 0.0.4
+  blf_TAG: 0.2.0
+  GTSAM_TAG: 4.0.3
+
+jobs:
+  build:
+    name: '[${{ matrix.os }}@${{ matrix.build_type }}@conda]'
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        build_type: [Release]
+        os: [ubuntu-latest, windows-latest, macos-latest]
+      fail-fast: false
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - uses: conda-incubator/setup-miniconda@v2
+      with:
+        mamba-version: "*"
+        channels: conda-forge,defaults
+        channel-priority: true
+
+    - name: Dependencies
+      shell: bash -l {0}
+      run: |
+        # Compilation related dependencies
+        mamba install cmake compilers make ninja pkg-config
+        # Actual dependencies
+        mamba install -c robotology idyntree eigen manif spdlog libmatio matio-cpp opencv pcl catch2 yarp
+
+    - name: Dependencies [Source Based - Linux&macOS]
+      if: contains(matrix.os, 'macos') || contains(matrix.os, 'ubuntu')
+      shell: bash -l {0}
+      run: |
+        # GTSAM
+        cd ${GITHUB_WORKSPACE}
+        git clone -b ${GTSAM_TAG} https://github.com/borglab/gtsam
+        cd gtsam
+        mkdir -p build
+        cd build
+        cmake -GNinja -DCMAKE_INSTALL_PREFIX=${CONDA_PREFIX} ..
+        cmake --build . --config ${{ matrix.build_type }} --target install
+
+        # bipedal-locomotion-framework
+        cd ${GITHUB_WORKSPACE}
+        git clone -b ${blf_TAG} https://github.com/dic-iit/bipedal-locomotion-framework
+        cd bipedal-locomotion-framework
+        mkdir -p build
+        cd build
+        cmake -GNinja -DCMAKE_INSTALL_PREFIX=${CONDA_PREFIX} ..
+        cmake --build . --config ${{ matrix.build_type }} --target install
+
+    - name: Dependencies [Source Based - windows]
+      if: contains(matrix.os, 'windows')
+      shell: bash -l {0}
+      run: |
+        # GTSAM
+        cd ${GITHUB_WORKSPACE}
+        git clone -b ${GTSAM_TAG} https://github.com/borglab/gtsam
+        cd gtsam
+        mkdir -p build
+        cd build
+        cmake -G"Visual Studio 16 2019" \
+              -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
+              -DCMAKE_INSTALL_PREFIX=${CONDA_PREFIX}/Library ..
+        cmake --build . --config ${{ matrix.build_type }} --target install
+
+        # bipedal-locomotion-framework
+        cd ${GITHUB_WORKSPACE}
+        git clone -b ${blf_TAG} https://github.com/dic-iit/bipedal-locomotion-framework
+        cd bipedal-locomotion-framework
+        mkdir -p build
+        cd build
+        cmake -G"Visual Studio 16 2019" \
+              -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
+              -DCMAKE_INSTALL_PREFIX=${CONDA_PREFIX}/Library ..
+        cmake --build . --config ${{ matrix.build_type }} --target install
+
+    - name: Configure [Linux&macOS]
+      if: contains(matrix.os, 'macos') || contains(matrix.os, 'ubuntu')
+      shell: bash -l {0}
+      run: |
+        mkdir -p build
+        cd build
+        cmake -GNinja -DBUILD_TESTING:BOOL=ON \
+              -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} ..
+
+    - name: Configure [Windows]
+      if: contains(matrix.os, 'windows')
+      shell: bash -l {0}
+      run: |
+        mkdir -p build
+        cd build
+        cmake -G"Visual Studio 16 2019" -DBUILD_TESTING:BOOL=ON \
+              -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} ..
+
+    - name: Build
+      shell: bash -l {0}
+      run: |
+        cd build
+        cmake --build . --config ${{ matrix.build_type }}
+
+    - name: Test
+      shell: bash -l {0}
+      run: |
+        cd build
+        ctest --output-on-failure -C ${{ matrix.build_type }}
+

--- a/.github/workflows/conda-ci.yml
+++ b/.github/workflows/conda-ci.yml
@@ -19,7 +19,8 @@ jobs:
     strategy:
       matrix:
         build_type: [Release]
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [macos-latest]
+        #os: [ubuntu-latest, windows-latest, macos-latest]
       fail-fast: false
 
     steps:
@@ -39,17 +40,17 @@ jobs:
         # Actual dependencies
         mamba install -c robotology idyntree eigen manif spdlog libmatio matio-cpp opencv pcl catch2 yarp nlohmann_json
 
-    - name: Boost Dependency [Ubuntu]
-      if: contains(matrix.os, 'ubuntu')
-      shell: bash -l {0}
-      run: |
-        mamba install boost=1.58.0
+    #- name: Boost Dependency [Ubuntu]
+    #  if: contains(matrix.os, 'ubuntu')
+    #  shell: bash -l {0}
+    #  run: |
+    #    mamba install boost=1.58.0
 
-    - name: Boost Dependency [Windows]
-      if: contains(matrix.os, 'windows')
-      shell: bash -l {0}
-      run: |
-        mamba install boost=1.67.0
+    #- name: Boost Dependency [Windows]
+    #  if: contains(matrix.os, 'windows')
+    #  shell: bash -l {0}
+    #  run: |
+    #    mamba install boost=1.67.0
 
     - name: Boost Dependency [MacOS]
       if: contains(matrix.os, 'macos')
@@ -57,24 +58,21 @@ jobs:
       run: |
         mamba install -c robotology boost
 
-    - name: GTSAM Dependency [Source Based - Linux]
-      if: contains(matrix.os, 'ubuntu')
-      env:
-          BOOST_ROOT: ${{ steps.install-boost-windows.outputs.BOOST_ROOT }}
-      shell: bash -l {0}
-      run: |
-        # GTSAM
-        cd ${GITHUB_WORKSPACE}
-        git clone https://github.com/borglab/gtsam
-        cd gtsam
-        mkdir -p build
-        cd build
-        cmake -GNinja \
-              -DBOOST_ROOT="${env:BOOST_ROOT}" \
-              -DBOOST_INCLUDEDIR="${env:BOOST_ROOT}\boost\include" \
-              -DBOOST_LIBRARYDIR="${env:BOOST_ROOT}\lib" \
-              -DCMAKE_INSTALL_PREFIX=${CONDA_PREFIX} ..
-        cmake --build . --config ${{ matrix.build_type }} --target install
+    #- name: GTSAM Dependency [Source Based - Linux]
+    #  if: contains(matrix.os, 'ubuntu')
+    #   env:
+    #      BOOST_ROOT: ${{ steps.install-boost-windows.outputs.BOOST_ROOT }}
+    #  shell: bash -l {0}
+    #  run: |
+    #    # GTSAM
+    #    cd ${GITHUB_WORKSPACE}
+    #    git clone https://github.com/borglab/gtsam
+    #    cd gtsam
+    #    mkdir -p build
+    #    cd build
+    #    cmake -GNinja \
+    #          -DCMAKE_INSTALL_PREFIX=${CONDA_PREFIX} ..
+    #    cmake --build . --config ${{ matrix.build_type }} --target install
 
     - name: GTSAM Dependency [Source Based - MacOS]
       if: contains(matrix.os, 'macos')
@@ -90,8 +88,9 @@ jobs:
               -DCMAKE_INSTALL_PREFIX=${CONDA_PREFIX} ..
         cmake --build . --config ${{ matrix.build_type }} --target install
 
-    - name: Dependencies [Source Based - Linux&MacOS]
-      if: contains(matrix.os, 'macos') || contains(matrix.os, 'ubuntu')
+    - name: Dependencies [Source Based - MacOS]
+      if: contains(matrix.os, 'macos')
+    #  if: contains(matrix.os, 'macos') || contains(matrix.os, 'ubuntu')
       shell: bash -l {0}
       run: |
         # bipedal-locomotion-framework
@@ -103,36 +102,37 @@ jobs:
         cmake -GNinja -DCMAKE_INSTALL_PREFIX=${CONDA_PREFIX} ..
         cmake --build . --config ${{ matrix.build_type }} --target install
 
-    - name: Dependencies [Source Based - windows]
-      if: contains(matrix.os, 'windows')
-      env:
-          BOOST_ROOT: ${{ steps.install-boost-windows.outputs.BOOST_ROOT }}
-      shell: bash -l {0}
-      run: |
-        # GTSAM
-        cd ${GITHUB_WORKSPACE}
-        git clone https://github.com/borglab/gtsam
-        cd gtsam
-        mkdir -p build
-        cd build
-        cmake -G"Visual Studio 16 2019" \
-              -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
-              -DCMAKE_INSTALL_PREFIX=${CONDA_PREFIX}/Library  ..
-        cmake --build . --config ${{ matrix.build_type }} --target install
+    #- name: Dependencies [Source Based - windows]
+    #  if: contains(matrix.os, 'windows')
+    #  env:
+    #      BOOST_ROOT: ${{ steps.install-boost-windows.outputs.BOOST_ROOT }}
+    #  shell: bash -l {0}
+    #  run: |
+    #    # GTSAM
+    #    cd ${GITHUB_WORKSPACE}
+    #    git clone https://github.com/borglab/gtsam
+    #    cd gtsam
+    #    mkdir -p build
+    #    cd build
+    #    cmake -G"Visual Studio 16 2019" \
+    #          -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
+    #          -DCMAKE_INSTALL_PREFIX=${CONDA_PREFIX}/Library  ..
+    #    cmake --build . --config ${{ matrix.build_type }} --target install
 
-        # bipedal-locomotion-framework
-        cd ${GITHUB_WORKSPACE}
-        git clone -b ${blf_TAG} https://github.com/dic-iit/bipedal-locomotion-framework
-        cd bipedal-locomotion-framework
-        mkdir -p build
-        cd build
-        cmake -G"Visual Studio 16 2019" \
-              -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
-              -DCMAKE_INSTALL_PREFIX=${CONDA_PREFIX}/Library ..
-        cmake --build . --config ${{ matrix.build_type }} --target install
+    #    # bipedal-locomotion-framework
+    #    cd ${GITHUB_WORKSPACE}
+    #    git clone -b ${blf_TAG} https://github.com/dic-iit/bipedal-locomotion-framework
+    #    cd bipedal-locomotion-framework
+    #    mkdir -p build
+    #    cd build
+    #    cmake -G"Visual Studio 16 2019" \
+    #          -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
+    #          -DCMAKE_INSTALL_PREFIX=${CONDA_PREFIX}/Library ..
+    #    cmake --build . --config ${{ matrix.build_type }} --target install
 
-    - name: Configure [Linux&MacOS]
-      if: contains(matrix.os, 'macos') || contains(matrix.os, 'ubuntu')
+    - name: Configure [MacOS]
+      if: contains(matrix.os, 'macos')
+   #   if: contains(matrix.os, 'macos') || contains(matrix.os, 'ubuntu')
       shell: bash -l {0}
       run: |
         mkdir -p build
@@ -140,14 +140,14 @@ jobs:
         cmake -GNinja -DBUILD_TESTING:BOOL=ON \
               -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} ..
 
-    - name: Configure [Windows]
-      if: contains(matrix.os, 'windows')
-      shell: bash -l {0}
-      run: |
-        mkdir -p build
-        cd build
-        cmake -G"Visual Studio 16 2019" -DBUILD_TESTING:BOOL=ON \
-              -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} ..
+    #- name: Configure [Windows]
+    #  if: contains(matrix.os, 'windows')
+    #  shell: bash -l {0}
+    #  run: |
+    #    mkdir -p build
+    #    cd build
+    #    cmake -G"Visual Studio 16 2019" -DBUILD_TESTING:BOOL=ON \
+    #          -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} ..
 
     - name: Build
       shell: bash -l {0}


### PR DESCRIPTION
This PR sets up CI workflow with macOS system configuration. (There are some unresolved issues with linux and windows worklfow related to boost and gtsam, see #19).
